### PR TITLE
57 update readme with proper instructions for running

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,36 +6,33 @@ TUQuiet is a simple web app that helps Temple students find the best study space
 
 # How to run
 
-To run this repo, you will need working JDK, Apache Maven, and Node.js installations. Maven is bundled into IntelliJ IDEA, and may be included in other Java-specific IDE installations, or may be installed from the web. Once you have those installations, follow the instructions below to run a local version of TUQuiet.
+To run this repo, you will need working JDKand Node.js installations (see links below). Once you have those installations, follow the instructions below to run a local version of TUQuiet.
 
 FIRST
 
-Clone this repository using the web url of this repository.
+Download the binary files from the most recent release of TUQuiet
+Uncompress them in your file explorer, or on the command line using 
 ```
-git clone [link]
+unzip tuquiet-0.1.0.zip
 ```
 
 THEN
 
-Open the new TUQuiet folder in an IDE. This has only been tested in Visual Studio Code, but should work in other IDEs which can run Maven projects and ReactJS. 
+Open the new tuquiet-0.1.0 folder in an IDE. This has only been tested in Visual Studio Code, but should work in other IDEs which can run Java projects and ReactJS. 
 
-Open a new terminal, and run this command:
+Open a new terminal to run the backend code.
+Ensure that you are in the correct folder by running the ls command. The output should look like this:
 ```
-cd backend
-```
-
-This will take you to the backend folder, which holds the Java code for TUQuiet.
-To run this code, run these commands in your terminal:
-```
-mvn clean install
-mvn spring-boot:run
+$ ls
+frontend/  tuquiet-0.1.0-SNAPSHOT.jar
 ```
 
-Open a second terminal. This should open in YourLocalPath\TUQuiet, but if it opens in backend again, use the command below to return to the TUQuiet directory:
+Now, to run the Spring Boot backend, run this command in your terminal:
 ```
-cd ..
+java -jar tuquiet-0.1.0-SNAPSHOT.jar
 ```
 
+Open a second terminal, and navigate to the same folder that you ran the backend in.
 Then, move to the frontend directory with the following command:
 ```
 cd frontend
@@ -48,6 +45,12 @@ npm run dev
 ```
 
 After the backend and frontend are working, navigate to localhost:5173 to view the TUQuiet webpage.
+
+# Links for JDK and Node.js installation
+
+https://www.oracle.com/java/technologies/downloads/#jdk24-mac (JDK - Mac)
+https://www.oracle.com/java/technologies/downloads/#jdk24-windows (JDK - Windows)
+https://nodejs.org/en/download (Node)
 
 # How to contribute
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ cd backend
 This will take you to the backend folder, which holds the Java code for TUQuiet.
 To run this code, run these commands in your terminal:
 ```
-mvn clean
-mvn validate
-mvn compile
+mvn clean install
 mvn spring-boot:run
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,38 +2,55 @@
 
 TUQuiet is a simple web app that helps Temple students find the best study spaces on campus through real-time peer reporting. Students can quickly report and view noise levels and crowdedness of popular study locations, and the system recommends the most suitable spots based on the current conditions.
 
-![This is a screenshot.](images.png)
+![image](https://github.com/user-attachments/assets/55d1c3d7-1205-4492-8575-e5082087debc)
 
 # How to run
 
-Provide here instructions on how to use your application.
+To run this repo, you will need working JDK, Apache Maven, and Node.js installations. Once those are installed, follow the below instructions to run a locally hosted TUQuiet.
 
-- Download the latest binary from the Release section on the right on GitHub.
-- On the command line uncompress using
+FIRST
 
+Clone this repository using the web url of this repository.
 ```
-tar -xzf
+git clone [link]
 ```
 
-- On the command line run with
+THEN
 
+Open the new TUQuiet folder in an IDE. This has only been tested in Visual Studio Code, but should work in other IDEs which can run Java and ReactJS.
+
+Open a new terminal, and run this command:
+```
+cd backend
+```
+
+This will take you to the backend folder, which holds the Java code for TUQuiet.
+To run this code, run these commands in your terminal:
 ```
 mvn clean
-mvn build
+mvn validate
+mvn compile
 mvn spring-boot:run
 ```
 
-- You will see "Welcome to TUQuiet - Find your perfect study space at Temple University!" on localhost:8080.
+Open a second terminal. This should open in YourLocalPath\TUQuiet, but if it opens in backend again, use the command below to return to the TUQuiet directory:
+```
+cd ..
+```
+
+Then, move to the frontend directory with the following command:
+```
+cd frontend
+```
+
+Now, run the following commands to start the frontend:
+```
+npm install
+npm run dev
+```
+
+After the backend and frontend are working, navigate to localhost:5173 to view the TUQuiet webpage.
 
 # How to contribute
 
-Follow this project board to know the latest status of the project: [http://...]([http://...])
-
-### How to build
-
-- Use this github repository: ...
-- Specify what branch to use for a more stable release or for cutting edge development.
-- Use InteliJ 11
-- Specify additional library to download if needed
-- What file and target to compile and run.
-- What is expected to happen when the app start.
+Follow this project board to know the latest status of the project: https://github.com/orgs/cis3296s25/projects/56/views/1?filterQuery=

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TUQuiet is a simple web app that helps Temple students find the best study space
 
 # How to run
 
-To run this repo, you will need working JDK and Node.js installations (see links below). If you are installing node.js or a JDK, the following commands can be helpful to check you have installed them properly:
+To run this repo, you will need working JDK and Node.js installations (see links below). If you are installing Node.js or a JDK, the following commands can be helpful to check you have installed them properly:
 
 ```
 node -v
@@ -18,7 +18,7 @@ Once you have the installations complete, follow the instructions below to run a
 FIRST
 
 Download the binary files from the most recent release of TUQuiet
-Uncompress them in your file explorer, or on the command line using 
+Uncompress them in your file explorer, or on the command line using:
 ```
 unzip tuquiet-0.1.0.zip
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ TUQuiet is a simple web app that helps Temple students find the best study space
 
 # How to run
 
-To run this repo, you will need working JDKand Node.js installations (see links below). Once you have those installations, follow the instructions below to run a local version of TUQuiet.
+To run this repo, you will need working JDKand Node.js installations (see links below). If you are installing node.js or a JDK, the following commands can be helpful to check you have installed them properly:
+
+```
+node -v
+java -version
+```
+
+Once you have the installations complete, follow the instructions below to run a local version of TUQuiet. 
 
 FIRST
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # TUQuiet
 
-TUQuiet is a simple web app that helps Temple students find the best study spaces on campus through real-time peer reporting. Students can quickly report and view noise levels and crowdedness of popular study locations, and the system recommends the most suitable spots based on the current conditions.
+TUQuiet is a simple web app that helps Temple students find the best study spaces on campus through real-time peer reporting. Currently, students can quickly report and view noise levels and crowdedness of popular study locations. In the future, the system will recommend the most suitable spots based on the current conditions.
 
 ![image](https://github.com/user-attachments/assets/55d1c3d7-1205-4492-8575-e5082087debc)
 
 # How to run
 
-To run this repo, you will need working JDK, Apache Maven, and Node.js installations. Once those are installed, follow the below instructions to run a locally hosted TUQuiet.
+To run this repo, you will need working JDK, Apache Maven, and Node.js installations. Maven is bundled into IntelliJ IDEA, and may be included in other Java-specific IDE installations, or may be installed from the web. Once you have those installations, follow the instructions below to run a local version of TUQuiet.
 
 FIRST
 
@@ -17,7 +17,7 @@ git clone [link]
 
 THEN
 
-Open the new TUQuiet folder in an IDE. This has only been tested in Visual Studio Code, but should work in other IDEs which can run Java and ReactJS.
+Open the new TUQuiet folder in an IDE. This has only been tested in Visual Studio Code, but should work in other IDEs which can run Maven projects and ReactJS. 
 
 Open a new terminal, and run this command:
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TUQuiet is a simple web app that helps Temple students find the best study space
 
 # How to run
 
-To run this repo, you will need working JDKand Node.js installations (see links below). If you are installing node.js or a JDK, the following commands can be helpful to check you have installed them properly:
+To run this repo, you will need working JDK and Node.js installations (see links below). If you are installing node.js or a JDK, the following commands can be helpful to check you have installed them properly:
 
 ```
 node -v


### PR DESCRIPTION
Updated the readme with the instructions on how to run sprint 1's release
Note: for me, maven build does not work - not sure if this is an issue with the pom file or local machine, but to accomodate others who may have that issue I changed maven build to mvn validate and mvn compile. If whoever reviews can check the compile instructions work on their end, that would be great!